### PR TITLE
계좌 거래 기능

### DIFF
--- a/src/main/java/com/zerobase/fintech/common/enums/TransactionStatus.java
+++ b/src/main/java/com/zerobase/fintech/common/enums/TransactionStatus.java
@@ -1,0 +1,6 @@
+package com.zerobase.fintech.common.enums;
+
+public enum TransactionStatus {
+    SUCCESS,
+    FAILED,
+}

--- a/src/main/java/com/zerobase/fintech/common/enums/TransactionType.java
+++ b/src/main/java/com/zerobase/fintech/common/enums/TransactionType.java
@@ -1,0 +1,7 @@
+package com.zerobase.fintech.common.enums;
+
+public enum TransactionType {
+    DEPOSIT,
+    WITHDRAWAL,
+    TRANSFER,
+}

--- a/src/main/java/com/zerobase/fintech/common/util/AccountValidator.java
+++ b/src/main/java/com/zerobase/fintech/common/util/AccountValidator.java
@@ -3,19 +3,17 @@ package com.zerobase.fintech.common.util;
 import com.zerobase.fintech.common.enums.AccountStatus;
 import com.zerobase.fintech.entity.AccountEntity;
 import com.zerobase.fintech.repository.AccountRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.util.Objects;
 
+@RequiredArgsConstructor
 @Component
 public class AccountValidator {
 
     private final AccountRepository accountRepository;
-
-    public AccountValidator(AccountRepository accountRepository) {
-        this.accountRepository = accountRepository;
-    }
 
     // 계좌 번호 형식 확인
     public void validateAccountNumber(String accountNumber) {
@@ -41,6 +39,13 @@ public class AccountValidator {
     public void validateAccountNotClosed(AccountEntity account) {
         if (Objects.equals(account.getAccountStatus(), AccountStatus.CLOSED)) {
             throw new IllegalArgumentException("Account is already closed");
+        }
+    }
+
+    // 계좌 활성화 여부 확인
+    public void validateAccountNotActive(AccountEntity account) {
+        if (!Objects.equals(account.getAccountStatus(), AccountStatus.ACTIVE)) {
+            throw new IllegalArgumentException("Account is not active");
         }
     }
 

--- a/src/main/java/com/zerobase/fintech/common/util/AccountValidator.java
+++ b/src/main/java/com/zerobase/fintech/common/util/AccountValidator.java
@@ -36,7 +36,7 @@ public class AccountValidator {
     }
 
     // 계좌 해지 여부 확인
-    public void validateAccountNotClosed(AccountEntity account) {
+    public void validateAccountIsClosed(AccountEntity account) {
         if (Objects.equals(account.getAccountStatus(), AccountStatus.CLOSED)) {
             throw new IllegalArgumentException("Account is already closed");
         }
@@ -53,6 +53,13 @@ public class AccountValidator {
     public void validateBalanceIsZero(AccountEntity account) {
         if (account.getBalance().compareTo(BigDecimal.ZERO) > 0) {
             throw new IllegalArgumentException("Account balance must be zero before closing the account");
+        }
+    }
+
+    // 계좌 출금 잔액 확인
+    public void validateBalanceIsMoreThanAmount(AccountEntity account, BigDecimal amount) {
+        if (account.getBalance().compareTo(amount) < 0) {
+            throw new IllegalArgumentException("Account balance must be equal to or greater than the amount");
         }
     }
 }

--- a/src/main/java/com/zerobase/fintech/common/util/TransactionValidator.java
+++ b/src/main/java/com/zerobase/fintech/common/util/TransactionValidator.java
@@ -1,0 +1,16 @@
+package com.zerobase.fintech.common.util;
+
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+@Component
+public class TransactionValidator {
+
+    // 거래 금액 양수 확인
+    public void validateTransactionAmountIsPositive(BigDecimal amount) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Transaction amount must be greater than zero and not null");
+        }
+    }
+}

--- a/src/main/java/com/zerobase/fintech/common/util/TransactionValidator.java
+++ b/src/main/java/com/zerobase/fintech/common/util/TransactionValidator.java
@@ -3,6 +3,7 @@ package com.zerobase.fintech.common.util;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 @Component
 public class TransactionValidator {
@@ -11,6 +12,19 @@ public class TransactionValidator {
     public void validateTransactionAmountIsPositive(BigDecimal amount) {
         if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
             throw new IllegalArgumentException("Transaction amount must be greater than zero and not null");
+        }
+    }
+
+    // 거래 대상 계좌 불일치 검증
+    public void validateTransactionAccountsAreDifferent(String account1, String account2) {
+        // 입력 값 검증
+        if (account1 == null || account2 == null) {
+            throw new IllegalArgumentException("Account numbers cannot be null");
+        }
+
+        // 계좌 번호 일치 여부 확인
+        if (Objects.equals(account1, account2)) {
+            throw new IllegalArgumentException("Transaction cannot occur between the same accounts");
         }
     }
 }

--- a/src/main/java/com/zerobase/fintech/controller/AccountController.java
+++ b/src/main/java/com/zerobase/fintech/controller/AccountController.java
@@ -8,6 +8,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @RequestMapping("api/accounts")
 @RestController
@@ -54,5 +56,13 @@ public class AccountController {
         AccountEntity account = accountService.deleteExternalAccount(accountNumber);
 
         return AccountResponse.DeleteExternalResponse.of(account);
+    }
+
+    @GetMapping("/list/{userId}")
+    public List<AccountResponse.ListResponse> getAccountListByUserId(
+            @PathVariable Long userId) {
+        List<AccountEntity> accountList = accountService.showAccountList(userId);
+
+        return AccountResponse.ListResponse.of(accountList);
     }
 }

--- a/src/main/java/com/zerobase/fintech/controller/TransactionController.java
+++ b/src/main/java/com/zerobase/fintech/controller/TransactionController.java
@@ -6,9 +6,10 @@ import com.zerobase.fintech.entity.TransactionEntity;
 import com.zerobase.fintech.service.TransactionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("api/transactions")
@@ -45,10 +46,11 @@ public class TransactionController {
     }
 
     @GetMapping("history/{accountNumber}")
-    public List<TransactionResponse.HistoryResponse> getTransactionsHistory(
-            @PathVariable String accountNumber
+    public Slice<TransactionResponse.HistoryResponse> getTransactionsHistory(
+            @PathVariable String accountNumber,
+            @PageableDefault(size = 10) Pageable pageable
     ) {
-        List<TransactionEntity> transactionHistories = transactionService.showTransactionHistory(accountNumber);
+        Slice<TransactionEntity> transactionHistories = transactionService.showTransactionHistory(accountNumber, pageable);
 
         return TransactionResponse.HistoryResponse.of(transactionHistories, accountNumber);
     }

--- a/src/main/java/com/zerobase/fintech/controller/TransactionController.java
+++ b/src/main/java/com/zerobase/fintech/controller/TransactionController.java
@@ -6,10 +6,9 @@ import com.zerobase.fintech.entity.TransactionEntity;
 import com.zerobase.fintech.service.TransactionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("api/transactions")
@@ -43,6 +42,15 @@ public class TransactionController {
         TransactionEntity transaction = transactionService.transfer(request);
 
         return TransactionResponse.TransferResponse.of(transaction);
+    }
+
+    @GetMapping("history/{accountNumber}")
+    public List<TransactionResponse.HistoryResponse> getTransactionsHistory(
+            @PathVariable String accountNumber
+    ) {
+        List<TransactionEntity> transactionHistories = transactionService.showTransactionHistory(accountNumber);
+
+        return TransactionResponse.HistoryResponse.of(transactionHistories, accountNumber);
     }
 
 }

--- a/src/main/java/com/zerobase/fintech/controller/TransactionController.java
+++ b/src/main/java/com/zerobase/fintech/controller/TransactionController.java
@@ -20,11 +20,20 @@ public class TransactionController {
 
     @PostMapping("/deposit")
     public TransactionResponse.DepositResponse deposit(
-            @Valid @RequestBody TransactionRequest.DepositRequest request
+            @Valid @RequestBody TransactionRequest request
     ) {
         TransactionEntity transaction = transactionService.deposit(request);
 
         return TransactionResponse.DepositResponse.of(transaction);
+    }
+
+    @PostMapping("/withdrawal")
+    public TransactionResponse.WithdrawalResponse withdrawal(
+            @Valid @RequestBody TransactionRequest request
+    ) {
+        TransactionEntity transaction = transactionService.withdrawal(request);
+
+        return TransactionResponse.WithdrawalResponse.of(transaction);
     }
 
 }

--- a/src/main/java/com/zerobase/fintech/controller/TransactionController.java
+++ b/src/main/java/com/zerobase/fintech/controller/TransactionController.java
@@ -1,0 +1,30 @@
+package com.zerobase.fintech.controller;
+
+import com.zerobase.fintech.controller.dto.request.TransactionRequest;
+import com.zerobase.fintech.controller.dto.response.TransactionResponse;
+import com.zerobase.fintech.entity.TransactionEntity;
+import com.zerobase.fintech.service.TransactionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("api/transactions")
+@RestController
+public class TransactionController {
+
+    private final TransactionService transactionService;
+
+    @PostMapping("/deposit")
+    public TransactionResponse.DepositResponse deposit(
+            @Valid @RequestBody TransactionRequest.DepositRequest request
+    ) {
+        TransactionEntity transaction = transactionService.deposit(request);
+
+        return TransactionResponse.DepositResponse.of(transaction);
+    }
+
+}

--- a/src/main/java/com/zerobase/fintech/controller/TransactionController.java
+++ b/src/main/java/com/zerobase/fintech/controller/TransactionController.java
@@ -36,4 +36,13 @@ public class TransactionController {
         return TransactionResponse.WithdrawalResponse.of(transaction);
     }
 
+    @PostMapping("/transfer")
+    public TransactionResponse.TransferResponse transfer(
+            @Valid @RequestBody TransactionRequest.TransferRequest request
+    ) {
+        TransactionEntity transaction = transactionService.transfer(request);
+
+        return TransactionResponse.TransferResponse.of(transaction);
+    }
+
 }

--- a/src/main/java/com/zerobase/fintech/controller/dto/request/TransactionRequest.java
+++ b/src/main/java/com/zerobase/fintech/controller/dto/request/TransactionRequest.java
@@ -26,10 +26,6 @@ public class TransactionRequest {
     )
     private BigDecimal amount;
 
-    public static class DepositRequest extends TransactionRequest { }
-
-    public static class WithdrawalRequest extends TransactionRequest { }
-
     public static class TransferRequest extends TransactionRequest {
 
         @NotBlank(message = "Account Number is required")

--- a/src/main/java/com/zerobase/fintech/controller/dto/request/TransactionRequest.java
+++ b/src/main/java/com/zerobase/fintech/controller/dto/request/TransactionRequest.java
@@ -26,6 +26,7 @@ public class TransactionRequest {
     )
     private BigDecimal amount;
 
+    @Data
     public static class TransferRequest extends TransactionRequest {
 
         @NotBlank(message = "Account Number is required")

--- a/src/main/java/com/zerobase/fintech/controller/dto/request/TransactionRequest.java
+++ b/src/main/java/com/zerobase/fintech/controller/dto/request/TransactionRequest.java
@@ -1,0 +1,44 @@
+package com.zerobase.fintech.controller.dto.request;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+public class TransactionRequest {
+
+    // 계좌 번호 형식
+    @NotBlank(message = "Account Number is required")
+    @Pattern(
+            regexp = "\\d{10,20}",
+            message = "Account number must be between 10 and 20 digits"
+    )
+    private String accountNumber;
+
+    // 금액 형식
+    @NotNull(message = "Amount is required")
+    @DecimalMin(
+            value = "0.01", message = "Balance must be non-negative"
+    )
+    private BigDecimal amount;
+
+    public static class DepositRequest extends TransactionRequest { }
+
+    public static class WithdrawalRequest extends TransactionRequest { }
+
+    public static class TransferRequest extends TransactionRequest {
+
+        @NotBlank(message = "Account Number is required")
+        @Pattern(
+                regexp = "\\d{10,20}",
+                message = "Account number must be between 10 and 20 digits"
+        )
+        private String receiverAccountNumber;
+
+        private String memo;
+    }
+}

--- a/src/main/java/com/zerobase/fintech/controller/dto/response/AccountResponse.java
+++ b/src/main/java/com/zerobase/fintech/controller/dto/response/AccountResponse.java
@@ -2,7 +2,6 @@ package com.zerobase.fintech.controller.dto.response;
 
 import com.zerobase.fintech.common.enums.AccountStatus;
 import com.zerobase.fintech.entity.AccountEntity;
-import lombok.Data;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -11,124 +10,95 @@ import java.util.List;
 
 public class AccountResponse {
 
-    @Data
-    public static class CreateResponse {
-
-        private String bankName;
-        private String accountAlias;
-        private String accountNumber;
-
+    public record CreateResponse(
+            String bankName,
+            String accountAlias,
+            String accountNumber
+    ) {
         public static CreateResponse of(AccountEntity account) {
-            CreateResponse response = new CreateResponse();
-
-            response.bankName = account.getBankName();
-            response.accountAlias = account.getAccountAlias();
-            response.accountNumber = account.getAccountNumber();
-
-            return response;
+            return new CreateResponse(
+                    account.getBankName(),
+                    account.getAccountAlias(),
+                    account.getAccountNumber()
+            );
         }
     }
 
-    @Data
-    public static class UpdateResponse {
-
-        private String beforeAccountNumber;
-        private String afterAccountNumber;
-
-        public static UpdateResponse of(String accountNumber,
-                                        AccountEntity account) {
-            UpdateResponse response = new UpdateResponse();
-
-            response.beforeAccountNumber = accountNumber;
-            response.afterAccountNumber = account.getAccountNumber();
-
-            return response;
+    public record UpdateResponse(
+            String beforeAccountNumber,
+            String afterAccountNumber) {
+        public static UpdateResponse of(String accountNumber, AccountEntity account) {
+            return new UpdateResponse(
+                    accountNumber,
+                    account.getAccountNumber()
+            );
         }
     }
 
-    @Data
-    public static class CloseResponse {
-
-        private String accountNumber;
-        private String accountAlias;
-        private AccountStatus accountStatus;
-        private LocalDateTime closeTime;
-
+    public record CloseResponse(
+            String accountNumber,
+            String accountAlias,
+            AccountStatus accountStatus,
+            LocalDateTime closeTime) {
         public static CloseResponse of(AccountEntity account) {
-            CloseResponse response = new CloseResponse();
-
-            response.accountNumber = account.getAccountNumber();
-            response.accountAlias = account.getAccountAlias();
-            response.accountStatus = account.getAccountStatus();
-            response.closeTime = account.getClosedAt();
-
-            return response;
+            return new CloseResponse(
+                    account.getAccountNumber(),
+                    account.getAccountAlias(),
+                    account.getAccountStatus(),
+                    account.getClosedAt()
+            );
         }
     }
 
-    @Data
-    public static class AddExternalResponse {
-
-        private String bankName;
-        private String accountAlias;
-        private String accountNumber;
-        private BigDecimal balance;
-
+    public record AddExternalResponse(
+            String bankName,
+            String accountAlias,
+            String accountNumber,
+            BigDecimal balance) {
         public static AddExternalResponse of(AccountEntity account) {
-            AddExternalResponse response = new AddExternalResponse();
-
-            response.bankName = account.getBankName();
-            response.accountAlias = account.getAccountAlias();
-            response.accountNumber = account.getAccountNumber();
-            response.balance = account.getBalance();
-
-            return response;
+            return new AddExternalResponse(
+                    account.getBankName(),
+                    account.getAccountAlias(),
+                    account.getAccountNumber(),
+                    account.getBalance()
+            );
         }
     }
 
-    @Data
-    public static class DeleteExternalResponse {
-
-        private String bankName;
-        private String accountAlias;
-        private String accountNumber;
-        private AccountStatus accountStatus;
-
+    public record DeleteExternalResponse(
+            String bankName,
+            String accountAlias,
+            String accountNumber,
+            AccountStatus accountStatus) {
         public static DeleteExternalResponse of(AccountEntity account) {
-            DeleteExternalResponse response = new DeleteExternalResponse();
-
-            response.bankName = account.getBankName();
-            response.accountAlias = account.getAccountAlias();
-            response.accountNumber = account.getAccountNumber();
-            response.accountStatus = account.getAccountStatus();
-
-            return response;
+            return new DeleteExternalResponse(
+                    account.getBankName(),
+                    account.getAccountAlias(),
+                    account.getAccountNumber(),
+                    account.getAccountStatus()
+            );
         }
     }
 
-    @Data
-    public static class ListResponse {
-
-        private String accountNumber;
-        private String accountAlias;
-        private BigDecimal balance;
-        private AccountStatus accountStatus;
-
+    public record ListResponse(
+            String accountNumber,
+            String accountAlias,
+            BigDecimal balance,
+            AccountStatus accountStatus) {
         public static List<ListResponse> of(List<AccountEntity> accounts) {
             List<ListResponse> responses = new ArrayList<>();
 
             for (AccountEntity accountEntity : accounts) {
-                ListResponse response = new ListResponse();
-
-                response.accountNumber = accountEntity.getAccountNumber();
-                response.accountAlias = accountEntity.getAccountAlias();
-                response.balance = accountEntity.getBalance();
-                response.accountStatus = accountEntity.getAccountStatus();
-
-                responses.add(response);
+                responses.add(new ListResponse(
+                        accountEntity.getAccountNumber(),
+                        accountEntity.getAccountAlias(),
+                        accountEntity.getBalance(),
+                        accountEntity.getAccountStatus()
+                ));
             }
 
             return responses;
         }
     }
 }
+

--- a/src/main/java/com/zerobase/fintech/controller/dto/response/AccountResponse.java
+++ b/src/main/java/com/zerobase/fintech/controller/dto/response/AccountResponse.java
@@ -6,6 +6,8 @@ import lombok.Data;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public class AccountResponse {
 
@@ -101,6 +103,32 @@ public class AccountResponse {
             response.accountStatus = account.getAccountStatus();
 
             return response;
+        }
+    }
+
+    @Data
+    public static class ListResponse {
+
+        private String accountNumber;
+        private String accountAlias;
+        private BigDecimal balance;
+        private AccountStatus accountStatus;
+
+        public static List<ListResponse> of(List<AccountEntity> accounts) {
+            List<ListResponse> responses = new ArrayList<>();
+
+            for (AccountEntity accountEntity : accounts) {
+                ListResponse response = new ListResponse();
+
+                response.accountNumber = accountEntity.getAccountNumber();
+                response.accountAlias = accountEntity.getAccountAlias();
+                response.balance = accountEntity.getBalance();
+                response.accountStatus = accountEntity.getAccountStatus();
+
+                responses.add(response);
+            }
+
+            return responses;
         }
     }
 }

--- a/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
+++ b/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
@@ -55,4 +55,30 @@ public class TransactionResponse {
             return response;
         }
     }
+
+    @Data
+    public static class TransferResponse {
+
+        private String senderAccountNumber;
+        private String receiverAccountNumber;
+        private String amount;
+        private String balance;
+        private String memo;
+        private TransactionType transactionType;
+        private TransactionStatus transactionStatus;
+
+        public static TransferResponse of(TransactionEntity transaction) {
+            TransferResponse response = new TransferResponse();
+
+            response.senderAccountNumber = transaction.getSenderAccount().getAccountNumber();
+            response.receiverAccountNumber = transaction.getReceiverAccount().getAccountNumber();
+            response.amount = transaction.getAmount().toString();
+            response.balance = transaction.getSenderAccount().getBalance().toString();
+            response.memo = transaction.getMemo();
+            response.transactionType = transaction.getTransactionType();
+            response.transactionStatus = transaction.getTransactionStatus();
+
+            return response;
+        }
+    }
 }

--- a/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
+++ b/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
@@ -5,6 +5,7 @@ import com.zerobase.fintech.common.enums.TransactionType;
 import com.zerobase.fintech.entity.TransactionEntity;
 import lombok.Data;
 
+@Data
 public class TransactionResponse {
 
     @Data
@@ -23,6 +24,30 @@ public class TransactionResponse {
             response.receiverAccountNumber = transaction.getReceiverAccount().getAccountNumber();
             response.amount = transaction.getAmount().toString();
             response.balance = transaction.getReceiverAccount().getBalance().toString();
+            response.memo = transaction.getMemo();
+            response.transactionType = transaction.getTransactionType();
+            response.transactionStatus = transaction.getTransactionStatus();
+
+            return response;
+        }
+    }
+
+    @Data
+    public static class WithdrawalResponse {
+
+        private String senderAccountNumber;
+        private String amount;
+        private String balance;
+        private String memo;
+        private TransactionType transactionType;
+        private TransactionStatus transactionStatus;
+
+        public static WithdrawalResponse of(TransactionEntity transaction) {
+            WithdrawalResponse response = new WithdrawalResponse();
+
+            response.senderAccountNumber = transaction.getSenderAccount().getAccountNumber();
+            response.amount = transaction.getAmount().toString();
+            response.balance = transaction.getSenderAccount().getBalance().toString();
             response.memo = transaction.getMemo();
             response.transactionType = transaction.getTransactionType();
             response.transactionStatus = transaction.getTransactionStatus();

--- a/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
+++ b/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
@@ -3,8 +3,7 @@ package com.zerobase.fintech.controller.dto.response;
 import com.zerobase.fintech.common.enums.TransactionStatus;
 import com.zerobase.fintech.common.enums.TransactionType;
 import com.zerobase.fintech.entity.TransactionEntity;
-
-import java.util.List;
+import org.springframework.data.domain.Slice;
 
 public class TransactionResponse {
 
@@ -75,24 +74,26 @@ public class TransactionResponse {
             String balance,
             String memo
     ) {
-        public static List<HistoryResponse> of(List<TransactionEntity> transactions, String targetAccountNumber) {
-            return transactions.stream()
-                    .map(transaction -> {
-                        String balance = null;
-                        if (transaction.getSenderAccount() != null &&
-                                transaction.getSenderAccount().getAccountNumber().equals(targetAccountNumber)) {
-                            balance = transaction.getSnapshot().getSenderBalanceAfter().toString();
-                        } else if (transaction.getReceiverAccount() != null &&
-                                transaction.getReceiverAccount().getAccountNumber().equals(targetAccountNumber)) {
-                            balance = transaction.getSnapshot().getReceiverBalanceAfter().toString();
-                        }
-                        return new HistoryResponse(
-                                transaction.getAmount().toString(),
-                                balance,
-                                transaction.getMemo()
-                        );
-                    })
-                    .toList();
+        public static Slice<HistoryResponse> of(Slice<TransactionEntity> transactions, String targetAccountNumber) {
+            return transactions.map(transaction -> {
+                String balance = null;
+
+                // 요청된 계좌의 잔액만 선택
+                if (transaction.getSenderAccount() != null &&
+                        transaction.getSenderAccount().getAccountNumber().equals(targetAccountNumber)) {
+                    balance = transaction.getSnapshot().getSenderBalanceAfter().toString();
+                } else if (transaction.getReceiverAccount() != null &&
+                        transaction.getReceiverAccount().getAccountNumber().equals(targetAccountNumber)) {
+                    balance = transaction.getSnapshot().getReceiverBalanceAfter().toString();
+                }
+
+                // HistoryResponse 생성
+                return new HistoryResponse(
+                        transaction.getAmount().toString(),
+                        balance,
+                        transaction.getMemo()
+                );
+            });
         }
     }
 }

--- a/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
+++ b/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
@@ -3,112 +3,96 @@ package com.zerobase.fintech.controller.dto.response;
 import com.zerobase.fintech.common.enums.TransactionStatus;
 import com.zerobase.fintech.common.enums.TransactionType;
 import com.zerobase.fintech.entity.TransactionEntity;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 
-import java.util.ArrayList;
 import java.util.List;
 
-@Data
 public class TransactionResponse {
 
-    @Data
-    public static class BaseResponse {
-
-        private String amount;
-        private String balance;
-        private String memo;
-        private TransactionType transactionType;
-        private TransactionStatus transactionStatus;
-
-        public void populateCommonFields(TransactionEntity transaction) {
-            this.amount = transaction.getAmount().toString();
-            this.memo = transaction.getMemo();
-            this.transactionType = transaction.getTransactionType();
-            this.transactionStatus = transaction.getTransactionStatus();
-        }
-    }
-
-    @Data
-    @EqualsAndHashCode(callSuper = true)
-    public static class DepositResponse extends BaseResponse {
-        private String receiverAccountNumber;
-
+    public record DepositResponse(
+            String receiverAccountNumber,
+            String amount,
+            String balance,
+            String memo,
+            TransactionType transactionType,
+            TransactionStatus transactionStatus
+    ) {
         public static DepositResponse of(TransactionEntity transaction) {
-            DepositResponse response = new DepositResponse();
-
-            response.populateCommonFields(transaction);
-            response.receiverAccountNumber = transaction.getReceiverAccount().getAccountNumber();
-            response.setBalance(transaction.getReceiverAccount().getBalance().toString());
-
-            return response;
+            return new DepositResponse(
+                    transaction.getReceiverAccount().getAccountNumber(),
+                    transaction.getAmount().toString(),
+                    transaction.getReceiverAccount().getBalance().toString(),
+                    transaction.getMemo(),
+                    transaction.getTransactionType(),
+                    transaction.getTransactionStatus()
+            );
         }
     }
 
-    @Data
-    @EqualsAndHashCode(callSuper = true)
-    public static class WithdrawalResponse extends BaseResponse {
-        private String senderAccountNumber;
-
+    public record WithdrawalResponse(
+            String senderAccountNumber,
+            String amount,
+            String balance,
+            String memo,
+            TransactionType transactionType,
+            TransactionStatus transactionStatus
+    ) {
         public static WithdrawalResponse of(TransactionEntity transaction) {
-            WithdrawalResponse response = new WithdrawalResponse();
-
-            response.populateCommonFields(transaction);
-            response.senderAccountNumber = transaction.getSenderAccount().getAccountNumber();
-            response.setBalance(transaction.getSenderAccount().getBalance().toString());
-
-            return response;
+            return new WithdrawalResponse(
+                    transaction.getSenderAccount().getAccountNumber(),
+                    transaction.getAmount().toString(),
+                    transaction.getSenderAccount().getBalance().toString(),
+                    transaction.getMemo(),
+                    transaction.getTransactionType(),
+                    transaction.getTransactionStatus()
+            );
         }
     }
 
-    @Data
-    @EqualsAndHashCode(callSuper = true)
-    public static class TransferResponse extends BaseResponse {
-        private String senderAccountNumber;
-        private String receiverAccountNumber;
-
+    public record TransferResponse(
+            String senderAccountNumber,
+            String receiverAccountNumber,
+            String amount,
+            String balance,
+            String memo,
+            TransactionType transactionType,
+            TransactionStatus transactionStatus
+    ) {
         public static TransferResponse of(TransactionEntity transaction) {
-            TransferResponse response = new TransferResponse();
-
-            response.populateCommonFields(transaction);
-            response.senderAccountNumber = transaction.getSenderAccount().getAccountNumber();
-            response.receiverAccountNumber = transaction.getReceiverAccount().getAccountNumber();
-            response.setBalance(transaction.getSenderAccount().getBalance().toString());
-
-            return response;
+            return new TransferResponse(
+                    transaction.getSenderAccount().getAccountNumber(),
+                    transaction.getReceiverAccount().getAccountNumber(),
+                    transaction.getAmount().toString(),
+                    transaction.getSenderAccount().getBalance().toString(),
+                    transaction.getMemo(),
+                    transaction.getTransactionType(),
+                    transaction.getTransactionStatus()
+            );
         }
     }
 
-    @Data
-    public static class HistoryResponse {
-
-        private String amount;
-        private String balance;
-        private String memo;
-
+    public record HistoryResponse(
+            String amount,
+            String balance,
+            String memo
+    ) {
         public static List<HistoryResponse> of(List<TransactionEntity> transactions, String targetAccountNumber) {
-            List<HistoryResponse> responses = new ArrayList<>();
-
-            for (TransactionEntity transaction : transactions) {
-                HistoryResponse response = new HistoryResponse();
-
-                response.amount = transaction.getAmount().toString();
-
-                // 요청된 계좌의 잔액만 선택
-                if (transaction.getSenderAccount() != null &&
-                        transaction.getSenderAccount().getAccountNumber().equals(targetAccountNumber)) {
-                    response.balance = transaction.getSnapshot().getSenderBalanceAfter().toString();
-                } else if (transaction.getReceiverAccount() != null &&
-                        transaction.getReceiverAccount().getAccountNumber().equals(targetAccountNumber)) {
-                    response.balance = transaction.getSnapshot().getReceiverBalanceAfter().toString();
-                }
-
-                response.memo = transaction.getMemo();
-
-                responses.add(response);
-            }
-
-            return responses;
+            return transactions.stream()
+                    .map(transaction -> {
+                        String balance = null;
+                        if (transaction.getSenderAccount() != null &&
+                                transaction.getSenderAccount().getAccountNumber().equals(targetAccountNumber)) {
+                            balance = transaction.getSnapshot().getSenderBalanceAfter().toString();
+                        } else if (transaction.getReceiverAccount() != null &&
+                                transaction.getReceiverAccount().getAccountNumber().equals(targetAccountNumber)) {
+                            balance = transaction.getSnapshot().getReceiverBalanceAfter().toString();
+                        }
+                        return new HistoryResponse(
+                                transaction.getAmount().toString(),
+                                balance,
+                                transaction.getMemo()
+                        );
+                    })
+                    .toList();
         }
     }
 }

--- a/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
+++ b/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
@@ -6,6 +6,9 @@ import com.zerobase.fintech.entity.TransactionEntity;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Data
 public class TransactionResponse {
 
@@ -73,6 +76,39 @@ public class TransactionResponse {
             response.setBalance(transaction.getSenderAccount().getBalance().toString());
 
             return response;
+        }
+    }
+
+    @Data
+    public static class HistoryResponse {
+
+        private String amount;
+        private String balance;
+        private String memo;
+
+        public static List<HistoryResponse> of(List<TransactionEntity> transactions, String targetAccountNumber) {
+            List<HistoryResponse> responses = new ArrayList<>();
+
+            for (TransactionEntity transaction : transactions) {
+                HistoryResponse response = new HistoryResponse();
+
+                response.amount = transaction.getAmount().toString();
+
+                // 요청된 계좌의 잔액만 선택
+                if (transaction.getSenderAccount() != null &&
+                        transaction.getSenderAccount().getAccountNumber().equals(targetAccountNumber)) {
+                    response.balance = transaction.getSnapshot().getSenderBalanceAfter().toString();
+                } else if (transaction.getReceiverAccount() != null &&
+                        transaction.getReceiverAccount().getAccountNumber().equals(targetAccountNumber)) {
+                    response.balance = transaction.getSnapshot().getReceiverBalanceAfter().toString();
+                }
+
+                response.memo = transaction.getMemo();
+
+                responses.add(response);
+            }
+
+            return responses;
         }
     }
 }

--- a/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
+++ b/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
@@ -1,0 +1,33 @@
+package com.zerobase.fintech.controller.dto.response;
+
+import com.zerobase.fintech.common.enums.TransactionStatus;
+import com.zerobase.fintech.common.enums.TransactionType;
+import com.zerobase.fintech.entity.TransactionEntity;
+import lombok.Data;
+
+public class TransactionResponse {
+
+    @Data
+    public static class DepositResponse {
+
+        private String receiverAccountNumber;
+        private String amount;
+        private String balance;
+        private String memo;
+        private TransactionType transactionType;
+        private TransactionStatus transactionStatus;
+
+        public static DepositResponse of(TransactionEntity transaction) {
+            DepositResponse response = new DepositResponse();
+
+            response.receiverAccountNumber = transaction.getReceiverAccount().getAccountNumber();
+            response.amount = transaction.getAmount().toString();
+            response.balance = transaction.getReceiverAccount().getBalance().toString();
+            response.memo = transaction.getMemo();
+            response.transactionType = transaction.getTransactionType();
+            response.transactionStatus = transaction.getTransactionStatus();
+
+            return response;
+        }
+    }
+}

--- a/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
+++ b/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
@@ -49,9 +49,11 @@ public class TransactionResponse {
 
         public static WithdrawalResponse of(TransactionEntity transaction) {
             WithdrawalResponse response = new WithdrawalResponse();
+
             response.populateCommonFields(transaction);
             response.senderAccountNumber = transaction.getSenderAccount().getAccountNumber();
             response.setBalance(transaction.getSenderAccount().getBalance().toString());
+
             return response;
         }
     }
@@ -64,10 +66,12 @@ public class TransactionResponse {
 
         public static TransferResponse of(TransactionEntity transaction) {
             TransferResponse response = new TransferResponse();
+
             response.populateCommonFields(transaction);
             response.senderAccountNumber = transaction.getSenderAccount().getAccountNumber();
             response.receiverAccountNumber = transaction.getReceiverAccount().getAccountNumber();
             response.setBalance(transaction.getSenderAccount().getBalance().toString());
+
             return response;
         }
     }

--- a/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
+++ b/src/main/java/com/zerobase/fintech/controller/dto/response/TransactionResponse.java
@@ -4,80 +4,70 @@ import com.zerobase.fintech.common.enums.TransactionStatus;
 import com.zerobase.fintech.common.enums.TransactionType;
 import com.zerobase.fintech.entity.TransactionEntity;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 public class TransactionResponse {
 
     @Data
-    public static class DepositResponse {
+    public static class BaseResponse {
 
-        private String receiverAccountNumber;
         private String amount;
         private String balance;
         private String memo;
         private TransactionType transactionType;
         private TransactionStatus transactionStatus;
+
+        public void populateCommonFields(TransactionEntity transaction) {
+            this.amount = transaction.getAmount().toString();
+            this.memo = transaction.getMemo();
+            this.transactionType = transaction.getTransactionType();
+            this.transactionStatus = transaction.getTransactionStatus();
+        }
+    }
+
+    @Data
+    @EqualsAndHashCode(callSuper = true)
+    public static class DepositResponse extends BaseResponse {
+        private String receiverAccountNumber;
 
         public static DepositResponse of(TransactionEntity transaction) {
             DepositResponse response = new DepositResponse();
 
+            response.populateCommonFields(transaction);
             response.receiverAccountNumber = transaction.getReceiverAccount().getAccountNumber();
-            response.amount = transaction.getAmount().toString();
-            response.balance = transaction.getReceiverAccount().getBalance().toString();
-            response.memo = transaction.getMemo();
-            response.transactionType = transaction.getTransactionType();
-            response.transactionStatus = transaction.getTransactionStatus();
+            response.setBalance(transaction.getReceiverAccount().getBalance().toString());
 
             return response;
         }
     }
 
     @Data
-    public static class WithdrawalResponse {
-
+    @EqualsAndHashCode(callSuper = true)
+    public static class WithdrawalResponse extends BaseResponse {
         private String senderAccountNumber;
-        private String amount;
-        private String balance;
-        private String memo;
-        private TransactionType transactionType;
-        private TransactionStatus transactionStatus;
 
         public static WithdrawalResponse of(TransactionEntity transaction) {
             WithdrawalResponse response = new WithdrawalResponse();
-
+            response.populateCommonFields(transaction);
             response.senderAccountNumber = transaction.getSenderAccount().getAccountNumber();
-            response.amount = transaction.getAmount().toString();
-            response.balance = transaction.getSenderAccount().getBalance().toString();
-            response.memo = transaction.getMemo();
-            response.transactionType = transaction.getTransactionType();
-            response.transactionStatus = transaction.getTransactionStatus();
-
+            response.setBalance(transaction.getSenderAccount().getBalance().toString());
             return response;
         }
     }
 
     @Data
-    public static class TransferResponse {
-
+    @EqualsAndHashCode(callSuper = true)
+    public static class TransferResponse extends BaseResponse {
         private String senderAccountNumber;
         private String receiverAccountNumber;
-        private String amount;
-        private String balance;
-        private String memo;
-        private TransactionType transactionType;
-        private TransactionStatus transactionStatus;
 
         public static TransferResponse of(TransactionEntity transaction) {
             TransferResponse response = new TransferResponse();
-
+            response.populateCommonFields(transaction);
             response.senderAccountNumber = transaction.getSenderAccount().getAccountNumber();
             response.receiverAccountNumber = transaction.getReceiverAccount().getAccountNumber();
-            response.amount = transaction.getAmount().toString();
-            response.balance = transaction.getSenderAccount().getBalance().toString();
-            response.memo = transaction.getMemo();
-            response.transactionType = transaction.getTransactionType();
-            response.transactionStatus = transaction.getTransactionStatus();
-
+            response.setBalance(transaction.getSenderAccount().getBalance().toString());
             return response;
         }
     }

--- a/src/main/java/com/zerobase/fintech/entity/AccountSnapshot.java
+++ b/src/main/java/com/zerobase/fintech/entity/AccountSnapshot.java
@@ -3,9 +3,11 @@ package com.zerobase.fintech.entity;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 
 import java.math.BigDecimal;
 
+@Data
 @Builder
 @AllArgsConstructor
 @Embeddable

--- a/src/main/java/com/zerobase/fintech/entity/AccountSnapshot.java
+++ b/src/main/java/com/zerobase/fintech/entity/AccountSnapshot.java
@@ -1,0 +1,21 @@
+package com.zerobase.fintech.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+@Builder
+@AllArgsConstructor
+@Embeddable
+public class AccountSnapshot {
+
+    private BigDecimal senderBalanceBefore;
+    private BigDecimal senderBalanceAfter;
+
+    private BigDecimal receiverBalanceBefore;
+    private BigDecimal receiverBalanceAfter;
+
+    public AccountSnapshot() { }
+}

--- a/src/main/java/com/zerobase/fintech/entity/TransactionEntity.java
+++ b/src/main/java/com/zerobase/fintech/entity/TransactionEntity.java
@@ -1,0 +1,50 @@
+package com.zerobase.fintech.entity;
+
+import com.zerobase.fintech.common.enums.TransactionStatus;
+import com.zerobase.fintech.common.enums.TransactionType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "transaction")
+@Entity
+public class TransactionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private AccountEntity senderAccount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private AccountEntity receiverAccount;
+
+    private String memo;
+
+    private BigDecimal amount;
+
+    @Embedded
+    private AccountSnapshot snapshot;
+
+    @Enumerated(EnumType.STRING)
+    private TransactionType transactionType;
+
+    @Enumerated(EnumType.STRING)
+    private TransactionStatus transactionStatus;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime transactionCreatedAt;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime transactionClosedAt;
+}

--- a/src/main/java/com/zerobase/fintech/repository/AccountRepository.java
+++ b/src/main/java/com/zerobase/fintech/repository/AccountRepository.java
@@ -1,13 +1,17 @@
 package com.zerobase.fintech.repository;
 
+import com.zerobase.fintech.common.enums.AccountStatus;
 import com.zerobase.fintech.entity.AccountEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface AccountRepository extends JpaRepository<AccountEntity, Long> {
 
     Optional<AccountEntity> findByAccountNumber(String accountNumber);
+
+    List<AccountEntity> findByUserIdAndAccountStatusIn(Long userId, List<AccountStatus> statuses);
 }

--- a/src/main/java/com/zerobase/fintech/repository/TransactionRepository.java
+++ b/src/main/java/com/zerobase/fintech/repository/TransactionRepository.java
@@ -1,0 +1,9 @@
+package com.zerobase.fintech.repository;
+
+import com.zerobase.fintech.entity.TransactionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TransactionRepository extends JpaRepository<TransactionEntity, Long> {
+}

--- a/src/main/java/com/zerobase/fintech/repository/TransactionRepository.java
+++ b/src/main/java/com/zerobase/fintech/repository/TransactionRepository.java
@@ -3,18 +3,19 @@ package com.zerobase.fintech.repository;
 import com.zerobase.fintech.common.enums.TransactionStatus;
 import com.zerobase.fintech.entity.AccountEntity;
 import com.zerobase.fintech.entity.TransactionEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface TransactionRepository extends JpaRepository<TransactionEntity, Long> {
 
-    List<TransactionEntity> findByTransactionStatusAndSenderAccountOrReceiverAccount(
+    Slice<TransactionEntity> findByTransactionStatusAndSenderAccountOrReceiverAccount(
             TransactionStatus transactionStatus,
             AccountEntity senderAccount,
-            AccountEntity receiverAccount
+            AccountEntity receiverAccount,
+            Pageable pageable
     );
 
 }

--- a/src/main/java/com/zerobase/fintech/repository/TransactionRepository.java
+++ b/src/main/java/com/zerobase/fintech/repository/TransactionRepository.java
@@ -1,9 +1,20 @@
 package com.zerobase.fintech.repository;
 
+import com.zerobase.fintech.common.enums.TransactionStatus;
+import com.zerobase.fintech.entity.AccountEntity;
 import com.zerobase.fintech.entity.TransactionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface TransactionRepository extends JpaRepository<TransactionEntity, Long> {
+
+    List<TransactionEntity> findByTransactionStatusAndSenderAccountOrReceiverAccount(
+            TransactionStatus transactionStatus,
+            AccountEntity senderAccount,
+            AccountEntity receiverAccount
+    );
+
 }

--- a/src/main/java/com/zerobase/fintech/service/AccountService.java
+++ b/src/main/java/com/zerobase/fintech/service/AccountService.java
@@ -51,7 +51,7 @@ public class AccountService {
         accountValidator.validateAccountNumber(accountNumber);
         AccountEntity account = accountValidator.validateAccountExists(accountNumber);
         accountValidator.validateBankName(account);
-        accountValidator.validateAccountNotClosed(account);
+        accountValidator.validateAccountIsClosed(account);
 
         // TODO: 인증 기능을 통해 계좌 소유주인지 확인할 필요 있음
 
@@ -74,7 +74,7 @@ public class AccountService {
         accountValidator.validateAccountNumber(accountNumber);
         AccountEntity account = accountValidator.validateAccountExists(accountNumber);
         accountValidator.validateBankName(account);
-        accountValidator.validateAccountNotClosed(account);
+        accountValidator.validateAccountIsClosed(account);
         accountValidator.validateBalanceIsZero(account);
 
         // TODO: 인증 기능을 통해 계좌 소유주인지 확인할 필요 있음

--- a/src/main/java/com/zerobase/fintech/service/AccountService.java
+++ b/src/main/java/com/zerobase/fintech/service/AccountService.java
@@ -12,6 +12,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -126,5 +128,20 @@ public class AccountService {
         account.setClosedAt(LocalDateTime.now());
 
         return account;
+    }
+
+    public List<AccountEntity> showAccountList(Long userId) {
+
+        // TODO: 인증 작업 필요
+
+
+        return accountRepository.findByUserIdAndAccountStatusIn(
+                userId,
+                Arrays.asList(
+                        AccountStatus.ACTIVE,
+                        AccountStatus.DORMANT,
+                        AccountStatus.SUSPENDED,
+                        AccountStatus.INACTIVE)
+        );
     }
 }

--- a/src/main/java/com/zerobase/fintech/service/TransactionService.java
+++ b/src/main/java/com/zerobase/fintech/service/TransactionService.java
@@ -1,0 +1,101 @@
+package com.zerobase.fintech.service;
+
+import com.zerobase.fintech.common.enums.TransactionStatus;
+import com.zerobase.fintech.common.enums.TransactionType;
+import com.zerobase.fintech.common.util.AccountValidator;
+import com.zerobase.fintech.common.util.TransactionValidator;
+import com.zerobase.fintech.controller.dto.request.TransactionRequest;
+import com.zerobase.fintech.entity.AccountEntity;
+import com.zerobase.fintech.entity.AccountSnapshot;
+import com.zerobase.fintech.entity.TransactionEntity;
+import com.zerobase.fintech.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class TransactionService {
+
+    private final TransactionRepository transactionRepository;
+    private final AccountValidator accountValidator;
+    private final TransactionValidator transactionValidator;
+
+    public TransactionEntity deposit(TransactionRequest.DepositRequest request) {
+
+        // 거래 예정 금액
+        BigDecimal amount = request.getAmount();
+
+        TransactionEntity transaction = initializeTransaction(
+                TransactionType.DEPOSIT,
+                "입금");
+
+        try {
+            // TODO: 인증 기능 구현 후 계좌 소유주 검증 단계 추가
+            // 거래와 관련된 모든 정보 검증
+            accountValidator.validateAccountNumber(request.getAccountNumber());
+            AccountEntity account = accountValidator.validateAccountExists(request.getAccountNumber());
+            accountValidator.validateAccountNotActive(account);
+            transactionValidator.validateTransactionAmountIsPositive(amount);
+
+            // 검증 후 거래 기록 저장
+            transaction.setReceiverAccount(account);
+            transaction.setAmount(amount);
+
+            // snapshot 생성 및 저장
+            AccountSnapshot snapshot = createAccountSnapshot(null, account, amount);
+            transaction.setSnapshot(snapshot);
+
+            // 입금 작업 실시
+            performDeposit(account, amount);
+
+        } catch (Exception e) {
+            // 거래 실패 처리
+            return saveTransaction(transaction, TransactionStatus.FAILED);
+        }
+
+        // 거래 완료
+        return saveTransaction(transaction, TransactionStatus.SUCCESS);
+    }
+
+    // 거래 기록 생성
+    private TransactionEntity initializeTransaction(TransactionType type, String memo) {
+        return TransactionEntity.builder()
+                .transactionType(type)
+                .memo(memo)
+                .transactionCreatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    // 스냅샷 생성
+    private AccountSnapshot createAccountSnapshot(AccountEntity senderAccount,
+                                                  AccountEntity receiverAccount,
+                                                  BigDecimal amount) {
+        return AccountSnapshot.builder()
+                .senderBalanceBefore(senderAccount != null ? senderAccount.getBalance() : BigDecimal.ZERO)
+                .receiverBalanceBefore(receiverAccount != null ? receiverAccount.getBalance() : BigDecimal.ZERO)
+                .senderBalanceAfter(senderAccount != null ? senderAccount.getBalance().subtract(amount) : null)
+                .receiverBalanceAfter(receiverAccount != null ? receiverAccount.getBalance().add(amount) : null)
+                .build();
+    }
+
+    // 입금
+    private void performDeposit(AccountEntity account, BigDecimal amount) {
+        account.setBalance(account.getBalance().add(amount));
+    }
+
+    // 출금
+    private void performWithdrawal(AccountEntity account, BigDecimal amount) {
+        account.setBalance(account.getBalance().subtract(amount));
+    }
+
+    // 거래 상태 저장
+    private TransactionEntity saveTransaction(TransactionEntity transaction, TransactionStatus transactionStatus) {
+        transaction.setTransactionStatus(transactionStatus);
+        transaction.setTransactionClosedAt(LocalDateTime.now());
+
+        return transactionRepository.save(transaction);
+    }
+}

--- a/src/main/java/com/zerobase/fintech/service/TransactionService.java
+++ b/src/main/java/com/zerobase/fintech/service/TransactionService.java
@@ -10,12 +10,13 @@ import com.zerobase.fintech.entity.AccountSnapshot;
 import com.zerobase.fintech.entity.TransactionEntity;
 import com.zerobase.fintech.repository.TransactionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -142,7 +143,7 @@ public class TransactionService {
     }
 
     // 거래 기록 불러오기
-    public List<TransactionEntity> showTransactionHistory(String accountNumber) {
+    public Slice<TransactionEntity> showTransactionHistory(String accountNumber, Pageable pageable) {
 
         // 계좌 검증
         accountValidator.validateAccountNumber(accountNumber);
@@ -154,7 +155,8 @@ public class TransactionService {
         return transactionRepository.findByTransactionStatusAndSenderAccountOrReceiverAccount(
                 TransactionStatus.SUCCESS,
                 account,
-                account
+                account,
+                pageable
         );
     }
 

--- a/src/main/java/com/zerobase/fintech/service/TransactionService.java
+++ b/src/main/java/com/zerobase/fintech/service/TransactionService.java
@@ -11,6 +11,7 @@ import com.zerobase.fintech.entity.TransactionEntity;
 import com.zerobase.fintech.repository.TransactionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -23,6 +24,7 @@ public class TransactionService {
     private final AccountValidator accountValidator;
     private final TransactionValidator transactionValidator;
 
+    @Transactional
     public TransactionEntity deposit(TransactionRequest request) {
 
         // 거래 예정 금액
@@ -60,6 +62,7 @@ public class TransactionService {
         return saveTransaction(transaction, TransactionStatus.SUCCESS);
     }
 
+    @Transactional
     public TransactionEntity withdrawal(TransactionRequest request) {
 
         // 거래 예정 금액

--- a/src/main/java/com/zerobase/fintech/service/TransactionService.java
+++ b/src/main/java/com/zerobase/fintech/service/TransactionService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -138,6 +139,23 @@ public class TransactionService {
 
         // 거래 완료
         return saveTransaction(transaction, TransactionStatus.SUCCESS);
+    }
+
+    // 거래 기록 불러오기
+    public List<TransactionEntity> showTransactionHistory(String accountNumber) {
+
+        // 계좌 검증
+        accountValidator.validateAccountNumber(accountNumber);
+        AccountEntity account = accountValidator.validateAccountExists(accountNumber);
+
+        // TODO: 계좌 소유주 검증 필요
+
+
+        return transactionRepository.findByTransactionStatusAndSenderAccountOrReceiverAccount(
+                TransactionStatus.SUCCESS,
+                account,
+                account
+        );
     }
 
     // 출금 계좌 검증

--- a/src/main/java/com/zerobase/fintech/service/TransactionService.java
+++ b/src/main/java/com/zerobase/fintech/service/TransactionService.java
@@ -37,7 +37,7 @@ public class TransactionService {
         try {
             // TODO: 인증 기능 구현 후 계좌 소유주 검증 단계 추가
             // 계좌 검증
-            AccountEntity account = validateReceiverAccount(request.getAccountNumber(), amount);
+            AccountEntity account = validateReceiverAccount(request.getAccountNumber());
 
             // 검증 후 거래 기록 저장
             transaction.setReceiverAccount(account);
@@ -116,7 +116,7 @@ public class TransactionService {
             AccountEntity senderAccount = validateSenderAccount(request.getAccountNumber(), amount);
 
             // 입금 계좌 검증
-            AccountEntity receiverAccount = validateReceiverAccount(request.getReceiverAccountNumber(), amount);
+            AccountEntity receiverAccount = validateReceiverAccount(request.getReceiverAccountNumber());
 
             // 검증 후 거래 기록 저장
             transaction.setSenderAccount(senderAccount);
@@ -152,11 +152,10 @@ public class TransactionService {
     }
 
     // 입금 계좌 검증
-    private AccountEntity validateReceiverAccount(String accountNumber, BigDecimal amount) {
+    private AccountEntity validateReceiverAccount(String accountNumber) {
         accountValidator.validateAccountNumber(accountNumber);
         AccountEntity account = accountValidator.validateAccountExists(accountNumber);
         accountValidator.validateAccountNotActive(account);
-        transactionValidator.validateTransactionAmountIsPositive(amount);
 
         return account;
     }

--- a/src/main/java/com/zerobase/fintech/service/TransactionService.java
+++ b/src/main/java/com/zerobase/fintech/service/TransactionService.java
@@ -86,7 +86,7 @@ public class TransactionService {
             AccountSnapshot snapshot = createAccountSnapshot(account, null, amount);
             transaction.setSnapshot(snapshot);
 
-            // 입금 작업 실시
+            // 출금 작업 실시
             performWithdrawal(account, amount);
 
         } catch (Exception e) {

--- a/src/main/java/com/zerobase/fintech/service/TransactionService.java
+++ b/src/main/java/com/zerobase/fintech/service/TransactionService.java
@@ -38,7 +38,7 @@ public class TransactionService {
         try {
             // TODO: 인증 기능 구현 후 계좌 소유주 검증 단계 추가
             // 계좌 검증
-            AccountEntity account = validateReceiverAccount(request.getAccountNumber());
+            AccountEntity account = validateDepositAccount(request.getAccountNumber());
 
             // 검증 후 거래 기록 저장
             transaction.setReceiverAccount(account);
@@ -73,7 +73,7 @@ public class TransactionService {
         try {
             // TODO: 인증 기능 구현 후 계좌 소유주 검증 단계 추가
             // 계좌 검증
-            AccountEntity account = validateSenderAccount(request.getAccountNumber(), amount);
+            AccountEntity account = validateWithdrawalAccount(request.getAccountNumber(), amount);
 
             // 검증 후 거래 기록 저장
             transaction.setSenderAccount(account);
@@ -114,10 +114,10 @@ public class TransactionService {
         try {
             // TODO: 인증 기능 구현 후 계좌 소유주 검증 단계 추가
             // 출금 계좌 검증
-            AccountEntity senderAccount = validateSenderAccount(request.getAccountNumber(), amount);
+            AccountEntity senderAccount = validateWithdrawalAccount(request.getAccountNumber(), amount);
 
             // 입금 계좌 검증
-            AccountEntity receiverAccount = validateReceiverAccount(request.getReceiverAccountNumber());
+            AccountEntity receiverAccount = validateDepositAccount(request.getReceiverAccountNumber());
 
             // 검증 후 거래 기록 저장
             transaction.setSenderAccount(senderAccount);
@@ -159,7 +159,7 @@ public class TransactionService {
     }
 
     // 출금 계좌 검증
-    private AccountEntity validateSenderAccount(String accountNumber, BigDecimal amount) {
+    private AccountEntity validateWithdrawalAccount(String accountNumber, BigDecimal amount) {
         accountValidator.validateAccountNumber(accountNumber);
         AccountEntity account = accountValidator.validateAccountExists(accountNumber);
         accountValidator.validateAccountNotActive(account);
@@ -170,7 +170,7 @@ public class TransactionService {
     }
 
     // 입금 계좌 검증
-    private AccountEntity validateReceiverAccount(String accountNumber) {
+    private AccountEntity validateDepositAccount(String accountNumber) {
         accountValidator.validateAccountNumber(accountNumber);
         AccountEntity account = accountValidator.validateAccountExists(accountNumber);
         accountValidator.validateAccountNotActive(account);

--- a/src/test/http/account.http
+++ b/src/test/http/account.http
@@ -36,3 +36,6 @@ Content-Type: application/json
 ### 계좌 삭제 (다른 은행 계좌)
 DELETE http://localhost:8080/api/accounts/external/110123123456
 Content-Type: application/json
+
+### 계좌 조회
+GET http://localhost:8080/api/accounts/list/{userId}

--- a/src/test/http/transaction.http
+++ b/src/test/http/transaction.http
@@ -7,6 +7,15 @@ POST http://localhost:8080/api/transactions/deposit
 Content-Type: application/json
 
 {
-  "accountNumber": "",
-  "amount":
+  "accountNumber": "110123123456",
+  "amount": 50000
+}
+
+### 출금
+POST http://localhost:8080/api/transactions/withdrawal
+Content-Type: application/json
+
+{
+  "accountNumber": "110123123456",
+  "amount": 12000
 }

--- a/src/test/http/transaction.http
+++ b/src/test/http/transaction.http
@@ -1,0 +1,12 @@
+### GET request to example server
+GET https://examples.http-client.intellij.net/get
+    ?generated-in=IntelliJ IDEA
+
+### 입금
+POST http://localhost:8080/api/transactions/deposit
+Content-Type: application/json
+
+{
+  "accountNumber": "",
+  "amount":
+}

--- a/src/test/http/transaction.http
+++ b/src/test/http/transaction.http
@@ -30,3 +30,6 @@ Content-Type: application/json
   "memo": "transfer API Test",
   "amount": 50000
 }
+
+### 거래 기록 불러오기
+GET http://localhost:8080/api/transactions/history/110123123456

--- a/src/test/http/transaction.http
+++ b/src/test/http/transaction.http
@@ -19,3 +19,14 @@ Content-Type: application/json
   "accountNumber": "110123123456",
   "amount": 12000
 }
+
+### 송금
+POST http://localhost:8080/api/transactions/transfer
+Content-Type: application/json
+
+{
+  "accountNumber": "110123123456",
+  "receiverAccountNumber": "",
+  "memo": "transfer API Test",
+  "amount": 50000
+}


### PR DESCRIPTION
## 변경 사항
[//]: # (이 PR에서 어떤점들이 변경되었는지 기술. 가급적이면 as-is, to-be를 활용해서 작성)

[//]: # (현재 구현되어 있는 사항, 현재의 문제점 또는 한계, 변경 전의 기능이나 로직 설명)
### AS-IS

**거래 작업 전 검증 로직**

- 거래 대상이 되는 계좌는 예외없이 `ACTIVE` 상태여야한다
- 하나의 거래에서 `sender`와 `receiver`는 동일할 수 없다.
- `sender`는 거래 금액 이상의 잔액을 보유하고 있어야한다.
- 검증 로직을 통과하지 못하면 `FAILED`상태로 거래 기록이 남는다.
   - 실제 거래 작업은 실행되지 않는다.

**입금**

- 입금 계좌는 `receiver`로 저장된다.

**출금**

- 출금 계좌는 `sender`로 저장된다.

**송금**

- 송금 시에 사용자는 `memo`를 직접 작성할 수 있다.

**소유한 계좌 확인**

- 본인이 소유한 계좌 리스트를 확인할 수 있다.
- `accountNumber`, `accountAlias`, `balance`, `AccountStatus`의 정보를 확인 가능하다.
- `ACTIVE`, `DORMANT`, `SUSPENDED`, `INACTIVE` 상태의 계좌만 확인 가능하다.

**거래 기록 확인**

- 특정 계좌의 모든 거래 기록을 확인 가능하다.
- `TransactionStatus`가 `SUCCESS`인 기록만 확인 가능하다.

---

## 테스트
[//]: # (본 변경사항이 테스트가 되었는지 기술)

- [ ] 테스트 코드
- [x] API 테스트 